### PR TITLE
aria-selected -> aria-checked in VueSwitch.vue

### DIFF
--- a/src/components/VueSwitch.vue
+++ b/src/components/VueSwitch.vue
@@ -9,7 +9,7 @@
     :tabindex="disabled ? -1 : 0"
     role="checkbox"
     :aria-disabled="disabled"
-    :aria-selected="!!value"
+    :aria-checked="!!value"
     @click="toggleValue"
     @keydown.enter="focused = true; toggleValue($event)"
     @keydown.space="focused = true; toggleValue($event)"


### PR DESCRIPTION
Is it better to use `aria-checked` instead of `aria-selected` in `<VueSwitch>`?
Ref: https://w3c.github.io/aria/#switch
Thanks.