### PR TITLE
Fix useless v-bind:class in VueModal.vue

### DIFF
--- a/src/components/VueModal.vue
+++ b/src/components/VueModal.vue
@@ -8,9 +8,6 @@
   >
     <div
       class="vue-ui-modal"
-      :class="{
-        locked,
-      }"
       tabindex="0"
       role="dialog"
       aria-modal="true"


### PR DESCRIPTION
There is a line of code :
```
    <div
      class="vue-ui-modal"
      :class="{
        locked,
      }"
      tabindex="0"
      role="dialog"
      aria-modal="true"
      @keyup.esc="close()"
    >
```
and it's useless:
```
      :class="{
        locked,
      }"
```
