### PR TITLE
chore: move all dependencies to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "focus-visible": "^4.1.4",
-    "material-design-icons": "^3.0.1",
-    "v-tooltip": "^2.0.0-rc.33",
-    "vue-resize": "^0.4.4"
-  },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.0.0-beta.1",
     "@vue/cli-plugin-eslint": "^3.0.0-beta.1",
@@ -55,6 +49,8 @@
     "babel-preset-stage-2": "^6.24.1",
     "clean-css": "^4.1.8",
     "cross-env": "^5.1.3",
+    "focus-visible": "^4.1.4",
+    "material-design-icons": "^3.0.1",
     "nodemon": "^1.17.5",
     "postcss-focus-visible": "^2.0.0",
     "raw-loader": "^0.5.1",
@@ -71,7 +67,9 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "uglify-es": "^3.0.28",
+    "v-tooltip": "^2.0.0-rc.33",
     "vue": "^2.5.13",
+    "vue-resize": "^0.4.4",
     "vue-router": "^3.0.1",
     "vue-template-compiler": "^2.5.13",
     "vuex": "^3.0.1"


### PR DESCRIPTION
As we ship `dist/` to npm, all those dependencies have already been bundled by rollup. We should not bother users to download such big packages like `material-design-icons` (https://github.com/vuejs/vue-cli/issues/3077#issuecomment-458718517)