### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/docs-src/views/demos/TypeAhead.vue
+++ b/docs-src/views/demos/TypeAhead.vue
@@ -65,7 +65,7 @@ export default {
       if (!releases || !(releases instanceof Array)) return false
 
       this.versions = this.versions.concat(releases.map(
-        r => ({ value: /^v/.test(r.tag_name) ? r.tag_name.substr(1) : r.tag_name })
+        r => ({ value: /^v/.test(r.tag_name) ? r.tag_name.slice(1) : r.tag_name })
       ))
 
       const link = response.headers.get('Link')


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.